### PR TITLE
Add string-to-array support in ListOf type

### DIFF
--- a/src/ListOf.php
+++ b/src/ListOf.php
@@ -17,6 +17,8 @@ use Firehed\Input\Objects\InputObject;
  */
 class ListOf extends InputObject
 {
+    /** @var string */
+    private $separator;
 
     private $type;
 
@@ -26,8 +28,23 @@ class ListOf extends InputObject
         $this->type = $type;
     } // __construct
 
+    public function setSeparator(string $separator): self
+    {
+        $this->separator = $separator;
+        return $this;
+    }
+
     protected function validate($value): bool
     {
+        if (is_string($value) && $this->separator !== null) {
+            // explode(any, '') returns `['']` not `[]`; force an override
+            if ($value === '') {
+                $value = [];
+            } else {
+                $value = explode($this->separator, $value);
+            }
+            $this->setValue($value);
+        }
         if (!is_array($value)) {
             return false;
         }

--- a/tests/ListOfTest.php
+++ b/tests/ListOfTest.php
@@ -134,6 +134,7 @@ class ListOfTest extends \PHPUnit\Framework\TestCase
     {
         $text = new Text();
         $number = new Number();
+        $listOfText = (new ListOf($text))->setSeparator('|');
         return [
             [$text, '#', '', []],
             [$text, '#', 'foo', ['foo']],
@@ -149,6 +150,16 @@ class ListOfTest extends \PHPUnit\Framework\TestCase
             [$text, '|', 'foo|bar|baz', ['foo', 'bar', 'baz']],
             [$number, ',', '1,2,3', [1, 2, 3]],
             [$number, ',', '1,2.3', [1, 2.3]],
+            // This should recursively decode
+            [$listOfText, ',', 'a,b,c|d|e,f,g|h,,|', [
+                ['a'],
+                ['b'],
+                ['c', 'd', 'e'],
+                ['f'],
+                ['g', 'h'],
+                [],
+                ['',''],
+            ]],
         ];
     }
 

--- a/tests/ListOfTest.php
+++ b/tests/ListOfTest.php
@@ -118,11 +118,11 @@ class ListOfTest extends \PHPUnit\Framework\TestCase
      * @dataProvider separatorValues
      */
     public function testStringValuesAreAcceptedWithSeparator(
+        InputObject $io,
         string $separator,
         string $input,
         array $output
     ) {
-        $io = new Text();
         $listOf = new ListOf($io);
         $listOf->setSeparator($separator);
 
@@ -132,19 +132,23 @@ class ListOfTest extends \PHPUnit\Framework\TestCase
 
     public function separatorValues(): array
     {
+        $text = new Text();
+        $number = new Number();
         return [
-            ['#', '', []],
-            ['#', 'foo', ['foo']],
-            ['#', 'foo#bar', ['foo', 'bar']],
-            ['#', 'foo#bar#baz', ['foo', 'bar', 'baz']],
-            [',', '', []],
-            [',', 'foo', ['foo']],
-            [',', 'foo,bar', ['foo', 'bar']],
-            [',', 'foo,bar,baz', ['foo', 'bar', 'baz']],
-            ['|', '', []],
-            ['|', 'foo', ['foo']],
-            ['|', 'foo|bar', ['foo', 'bar']],
-            ['|', 'foo|bar|baz', ['foo', 'bar', 'baz']],
+            [$text, '#', '', []],
+            [$text, '#', 'foo', ['foo']],
+            [$text, '#', 'foo#bar', ['foo', 'bar']],
+            [$text, '#', 'foo#bar#baz', ['foo', 'bar', 'baz']],
+            [$text, ',', '', []],
+            [$text, ',', 'foo', ['foo']],
+            [$text, ',', 'foo,bar', ['foo', 'bar']],
+            [$text, ',', 'foo,bar,baz', ['foo', 'bar', 'baz']],
+            [$text, '|', '', []],
+            [$text, '|', 'foo', ['foo']],
+            [$text, '|', 'foo|bar', ['foo', 'bar']],
+            [$text, '|', 'foo|bar|baz', ['foo', 'bar', 'baz']],
+            [$number, ',', '1,2,3', [1, 2, 3]],
+            [$number, ',', '1,2.3', [1, 2.3]],
         ];
     }
 

--- a/tests/ListOfTest.php
+++ b/tests/ListOfTest.php
@@ -58,10 +58,7 @@ class ListOfTest extends \PHPUnit\Framework\TestCase
      */
     public function testEvaluate($input, $mock_returns, $is_valid)
     {
-        $io = $this->createMock(
-            InputObject::class,
-            ['validate', 'evaluate']
-        );
+        $io = $this->createMock(InputObject::class);
         $map = [];
         $out_map = [];
         foreach ($input as $i => $value) {
@@ -103,6 +100,53 @@ class ListOfTest extends \PHPUnit\Framework\TestCase
         $list_of->setValue($non_list);
         $this->assertFalse($list_of->isValid());
     } // testNonListsAreRejected
+
+    /**
+     * @covers ::setSeparator
+     */
+    public function testSetSeapratorReturnsThis()
+    {
+        $io = $this->createMock(InputObject::class);
+        $listOf = new ListOf($io);
+        $this->assertSame($listOf, $listOf->setSeparator(','));
+    }
+
+    /**
+     * @covers ::setSeparator
+     * @covers ::validate
+     * @covers ::evaluate
+     * @dataProvider separatorValues
+     */
+    public function testStringValuesAreAcceptedWithSeparator(
+        string $separator,
+        string $input,
+        array $output
+    ) {
+        $io = new Text();
+        $listOf = new ListOf($io);
+        $listOf->setSeparator($separator);
+
+        $listOf->setValue($input);
+        $this->assertSame($output, $listOf->evaluate());
+    }
+
+    public function separatorValues(): array
+    {
+        return [
+            ['#', '', []],
+            ['#', 'foo', ['foo']],
+            ['#', 'foo#bar', ['foo', 'bar']],
+            ['#', 'foo#bar#baz', ['foo', 'bar', 'baz']],
+            [',', '', []],
+            [',', 'foo', ['foo']],
+            [',', 'foo,bar', ['foo', 'bar']],
+            [',', 'foo,bar,baz', ['foo', 'bar', 'baz']],
+            ['|', '', []],
+            ['|', 'foo', ['foo']],
+            ['|', 'foo|bar', ['foo', 'bar']],
+            ['|', 'foo|bar|baz', ['foo', 'bar', 'baz']],
+        ];
+    }
 
     public function values()
     {


### PR DESCRIPTION
Creates optional flexibility for parsing strings into arrays, allowing for simple parameters (e.g. `foos=bar,baz` => `$foos = ['bar', 'baz']`)