### PR TITLE
Rework Enum type for improved ergonomics

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -6,8 +6,16 @@ namespace Firehed\InputObjects;
 
 use Firehed\Input\Objects\InputObject;
 
-abstract class Enum extends InputObject
+class Enum extends InputObject
 {
+    /** @var string[] */
+    private $validValues;
+
+    public function __construct(array $values)
+    {
+        parent::__construct();
+        $this->validValues = $values;
+    }
 
     /**
      * @param mixed $value value to validate
@@ -15,11 +23,6 @@ abstract class Enum extends InputObject
      */
     final protected function validate($value): bool
     {
-        return in_array($value, $this->getValidValues());
+        return in_array($value, $this->validValues, true);
     } // validate
-
-    /**
-     * @return array<string>
-     */
-    abstract protected function getValidValues(): array;
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -2,6 +2,8 @@
 
 namespace Firehed\InputObjects;
 
+use Firehed\Input\Objects\InputObject;
+
 /**
  * @coversDefaultClass Firehed\InputObjects\Enum
  * @covers ::<protected>
@@ -9,37 +11,42 @@ namespace Firehed\InputObjects;
  */
 class EnumTest extends \PHPUnit\Framework\TestCase
 {
+    use InputObjectTestTrait;
 
-    public function testValidValue()
+    public function getInputObject(): InputObject
     {
-        $fixture = $this->getFixture();
-        $fixture->setValue('hello');
-        $this->assertTrue($fixture->isValid(), 'Should have been valid');
-        $this->assertSame(
+        return new Enum([
             'hello',
-            $fixture->evaluate(),
-            'The wrong value was returned from evaluate'
-        );
-    } // testValidValue
+            'goodbye',
+            10,
+            5.5,
+            true
+        ]);
+    }
 
-    public function testInvalidValue()
+    public function evaluations(): array
     {
-        $fixture = $this->getFixture();
-        $fixture->setValue('hola');
-        $this->assertFalse($fixture->isValid(), 'Should have been invalid');
-    } // testInvalidValues
+        return [
+            ['hello', 'hello'],
+            ['goodbye', 'goodbye'],
+            [10, 10],
+            [5.5, 5.5],
+            [true, true],
+        ];
+    }
 
-    private function getFixture(): Enum
+    public function invalidEvaluations(): array
     {
-        return new class extends Enum
-        {
-            protected function getValidValues(): array
-            {
-                return [
-                    'hello',
-                    'goodbye',
-                ];
-            }
-        };
+        return [
+            ['hola'],
+            ['10'],
+            ['10.0'],
+            [(float) 10],
+            ['5.5'],
+            ['true'],
+            [1],
+            [null],
+            [false],
+        ];
     }
 }

--- a/tests/InputObjectTestTrait.php
+++ b/tests/InputObjectTestTrait.php
@@ -32,6 +32,17 @@ trait InputObjectTestTrait
     abstract public function invalidEvaluations(): array;
 
     /**
+     * @covers ::__construct
+     */
+    public function testConstruct()
+    {
+        $this->assertInstanceOf(
+            InputObject::class,
+            $this->getInputObject()
+        );
+    }
+
+    /**
      * @covers ::validate
      * @dataProvider evaluations
      */

--- a/tests/InputObjectTestTrait.php
+++ b/tests/InputObjectTestTrait.php
@@ -2,6 +2,8 @@
 
 namespace Firehed\InputObjects;
 
+use Firehed\Input\Objects\InputObject;
+
 trait InputObjectTestTrait
 {
     /**


### PR DESCRIPTION
A user can still subclass the enum type, but is no longer forced to do so.