### PR TITLE
Fix rare invalid evaluation due to object reuse

### DIFF
--- a/src/AnyOf.php
+++ b/src/AnyOf.php
@@ -36,7 +36,7 @@ class AnyOf extends InputObject
         $value = $this->getValue();
         foreach ($this->types as $type) {
             try {
-                if ($type->isValid()) {
+                if ($type->setValue($value)->isValid()) {
                     return $type->evaluate();
                 }
             } catch (InputException $e) {

--- a/tests/AnyOfTest.php
+++ b/tests/AnyOfTest.php
@@ -39,4 +39,13 @@ class AnyOfTest extends \PHPUnit\Framework\TestCase
             [[42]],
         ];
     }
+
+    public function testOptionalListOf()
+    {
+        $enum = new Enum(['a', 'b', 'c']);
+        $io = new AnyOf($enum, new ListOf($enum));
+        $input = ['c', 'b'];
+        $this->assertTrue($io->setValue($input)->isValid());
+        $this->assertSame($input, $io->setValue($input)->evaluate());
+    }
 }


### PR DESCRIPTION
Previously, the evaluation of `AnyOf` was relying on the side-effects during validation to perform the evaluation. It was possible to configure the structure such that validator reuse would result in the wrong value would be returned (primarily due to objects being passed by reference).

This adds a reproduce case as a (originally) failing test and implements a fix.