### PR TITLE
Improve phpunit8 compatibility

### DIFF
--- a/tests/InputObjectTestTrait.php
+++ b/tests/InputObjectTestTrait.php
@@ -3,6 +3,7 @@
 namespace Firehed\InputObjects;
 
 use Firehed\Input\Objects\InputObject;
+use UnexpectedValueException;
 
 trait InputObjectTestTrait
 {
@@ -79,11 +80,11 @@ trait InputObjectTestTrait
      * @covers ::evaluate
      * @covers ::validate
      * @dataProvider invalidEvaluations
-     * @expectedException UnexpectedValueException
      */
     public function testInvalidEvaluations($input_value)
     {
         $inputObject = $this->getInputObject();
+        $this->expectException(UnexpectedValueException::class);
         $inputObject->setValue($input_value)->evaluate();
     }
 }

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -2,6 +2,9 @@
 
 namespace Firehed\InputObjects;
 
+use InvalidArgumentException;
+use UnexpectedValueException;
+
 /**
  * @coversDefaultClass Firehed\InputObjects\Number
  * @covers ::<protected>
@@ -126,10 +129,10 @@ class NumberTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::setMax
      * @dataProvider invalidRangeValues
-     * @expectedException InvalidArgumentException
      */
     public function testInvalidMax($value)
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->number->setMax($value);
     } // testInvalidMax
 
@@ -150,10 +153,10 @@ class NumberTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::setMin
      * @dataProvider invalidRangeValues
-     * @expectedException InvalidArgumentException
      */
     public function testInvalidMin($value)
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->number->setMin($value);
     } // testInvalidMin
 
@@ -175,10 +178,10 @@ class NumberTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::setMax
      * @covers ::setMin
-     * @expectedException InvalidArgumentException
      */
     public function testIncompatibleMaxAfterMin()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->number->setMin(5)
             ->setMax(4);
     } // testIncompatibleMaxAfterMin
@@ -186,10 +189,10 @@ class NumberTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::setMax
      * @covers ::setMin
-     * @expectedException InvalidArgumentException
      */
     public function testIncompatibleMinAfterMax()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->number->setMax(4)
             ->setMin(5);
     } // testIncompatibleMinAfterMax
@@ -246,10 +249,10 @@ class NumberTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::evaluate
      * @dataProvider invalidEvaluations
-     * @expectedException UnexpectedValueException
      */
     public function testInvalidEvaliations($input_value)
     {
+        $this->expectException(UnexpectedValueException::class);
         $this->number->setValue($input_value)->evaluate();
     }
 }

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -2,6 +2,8 @@
 
 namespace Firehed\InputObjects;
 
+use InvalidArgumentException;
+
 /**
  * @coversDefaultClass Firehed\InputObjects\Text
  * @covers ::<protected>
@@ -86,10 +88,10 @@ class TextTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::setMax
      * @dataProvider invalidRangeValues
-     * @expectedException InvalidArgumentException
      */
     public function testInvalidMax($value)
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->text->setMax($value);
     } // testInvalidMax
 
@@ -110,10 +112,10 @@ class TextTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::setMin
      * @dataProvider invalidRangeValues
-     * @expectedException InvalidArgumentException
      */
     public function testInvalidMin($value)
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->text->setMin($value);
     } // testInvalidMin
 
@@ -135,10 +137,10 @@ class TextTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::setMax
      * @covers ::setMin
-     * @expectedException InvalidArgumentException
      */
     public function testIncompatibleMaxAfterMin()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->text->setMin(5)
             ->setMax(4);
     } // testIncompatibleMaxAfterMin
@@ -146,10 +148,10 @@ class TextTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::setMax
      * @covers ::setMin
-     * @expectedException InvalidArgumentException
      */
     public function testIncompatibleMinAfterMax()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->text->setMax(4)
             ->setMin(5);
     } // testIncompatibleMinAfterMax
@@ -170,10 +172,10 @@ class TextTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers ::setMax
-     * @expectedException InvalidArgumentException
      */
     public function testMaxOfZeroIsDisallowed()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->text->setMax(0);
     } // testMaxOfZeroIsDisallowed
 


### PR DESCRIPTION
This doesn't yet add `:void`, but that will be done in a the next major which will drop 7.0 support.